### PR TITLE
Allow "10*" prefixed domains as trusted

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - POSTGRES_PASSWORD_FILE=/run/secrets/postgres_password
       - NEXTCLOUD_ADMIN_PASSWORD_FILE=/run/secrets/nextcloud_admin_password
       - NEXTCLOUD_ADMIN_USER_FILE=/run/secrets/nextcloud_admin_user
-      - NEXTCLOUD_TRUSTED_DOMAINS=localhost 192.168.* 172.16* 10.* nextcloud.local
+      - NEXTCLOUD_TRUSTED_DOMAINS=localhost 192.168.* 172.16* 10* nextcloud.local
     depends_on:
       - db
     secrets:


### PR DESCRIPTION
I noticed today that I couldn't connect to Nextcloud in the "Bayern WLAN" because my IP addressed was prefixed with ` `100.`` but this wasn't in our trusted domain list, instead it was ``10.` `. With the wildcard ``10*`` it should hopefully cover all local IP addresses.